### PR TITLE
feat: monitoring and altering with prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ reducto_host = "reducto.example.com"
 cloudflare_api_token = "token"
 
 # For alerting
-slack_api_url = "webhook_or_api_url"
-slack_channel = "#channel"
+slack_webhook_url = "todo"
 ```
 
 ### Provisioning

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ reducto_helm_repo_username = "todo"
 reducto_helm_repo_password = "todo"
 reducto_host = "reducto.example.com"
 cloudflare_api_token = "token"
+
+# For alerting
+slack_api_url = "webhook_or_api_url"
+slack_channel = "#channel"
 ```
 
 ### Provisioning
@@ -120,3 +124,9 @@ To customize NLB configuration:
      targetPorts:
        https: http
    ```
+
+## Monitoring
+
+Reducto internal job queue length is a good indicator of overall worker health. And 5xx metric from Reducto ingress is a good indicator of API health. 
+
+`PrometheusRule` in `manifests/prometheus/rules/01-reducto.yaml` monitors internal queue length and 5xx metrics. When queue doesn't go down for a long duration OR API returns 5xx status for a long duration, alerts are sent to configured Slack channel.

--- a/manifests/prometheus/rules/01-reducto.yaml
+++ b/manifests/prometheus/rules/01-reducto.yaml
@@ -1,0 +1,38 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: reducto
+  namespace: monitoring
+spec:
+  groups:
+  - name: reducto
+    rules:
+    - alert: ReductoTaskQueueStuck
+      annotations:
+        description: Task queue on {{ $labels.environment }} has been stuck with {{ $value }} tasks.
+        summary: Check Reducto workers Pod statuses or logs
+      expr: reducto_tasks_count > 10
+      for: 30m
+      labels:
+        severity: critical
+    - alert: ReductoPriorityTaskQueueStuck
+      annotations:
+        description: Priority Task queue on {{ $labels.environment }} has been stuck with {{ $value }} tasks.
+        summary: Check Reducto workers Pod statuses or logs
+      expr: reducto_prioritytasks_count > 10
+      for: 30m
+      labels:
+        severity: critical
+    - alert: ReductoPersistent5XX
+      annotations:
+        description: Persistent 5XX HTTP requests.
+        summary: Check Reducto HTTP Pods or logs for 5XX errors
+      expr: |-
+        round(
+          sum(
+            increase(nginx_ingress_controller_requests{ingress="reducto-reducto-http-ingress",status=~"5.+"}[15m])
+          )
+        ) >= 5
+      for: 15m
+      labels:
+        severity: critical

--- a/manifests/prometheus/rules/01-reducto.yaml
+++ b/manifests/prometheus/rules/01-reducto.yaml
@@ -9,24 +9,21 @@ spec:
     rules:
     - alert: ReductoTaskQueueStuck
       annotations:
-        description: Task queue on {{ $labels.environment }} has been stuck with {{ $value }} tasks.
-        summary: Check Reducto workers Pod statuses or logs
+        description: Task queue has been stuck with {{ $value }} tasks for 30 mins. Check workers Pod statuses or logs
       expr: reducto_tasks_count > 10
       for: 30m
       labels:
         severity: critical
     - alert: ReductoPriorityTaskQueueStuck
       annotations:
-        description: Priority Task queue on {{ $labels.environment }} has been stuck with {{ $value }} tasks.
-        summary: Check Reducto workers Pod statuses or logs
+        description: Priority Task queue has been stuck with {{ $value }} tasks for 30 mins. Check workers Pod statuses or logs.
       expr: reducto_prioritytasks_count > 10
       for: 30m
       labels:
         severity: critical
     - alert: ReductoPersistent5XX
       annotations:
-        description: Persistent 5XX HTTP requests.
-        summary: Check Reducto HTTP Pods or logs for 5XX errors
+        description: Persistent 5XX HTTP requests. Check HTTP Pods or logs for errors.
       expr: |-
         round(
           sum(

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -63,3 +63,18 @@ resource "helm_release" "kube_prometheus_stack" {
     helm_release.ingress_nginx,
   ]
 }
+
+
+data "kubectl_filename_list" "prometheus_rules" {
+  pattern = "./manifests/prometheus/rules/*.yaml"
+}
+
+resource "kubectl_manifest" "prometheus_rules" {
+  count     = length(data.kubectl_filename_list.prometheus_rules.matches)
+  yaml_body = file(element(data.kubectl_filename_list.prometheus_rules.matches, count.index))
+
+  depends_on = [
+    helm_release.prometheus_crds,
+    helm_release.kube_prometheus_stack,
+  ]
+}

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -46,12 +46,12 @@ resource "helm_release" "kube_prometheus_stack" {
     alertmanager:
       config:
         global:
-          slack_api_url: ${var.slack_api_url}
+          slack_api_url: ${var.slack_webhook_url}
         receivers:
         - name: blackhole
         - name: reducto-alerts
           slack_configs:
-          - channel: '${var.slack_channel}'
+          - channel: '#reducto-alerts'
             send_resolved: true
     EOT
 

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -24,3 +24,42 @@ resource "helm_release" "prometheus_crds" {
     kubectl_manifest.monitoring_ns,
   ]
 }
+
+# Alertmanager config doc:
+# https://prometheus.io/docs/alerting/latest/configuration/#receiver-integration-settings
+resource "helm_release" "kube_prometheus_stack" {
+  name             = "prometheus-stack"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "kube-prometheus-stack"
+  version          = "72.2.0"
+  namespace        = "monitoring"
+  create_namespace = false
+
+  values = [
+    "${file("values/kube-prometheus-stack.yaml")}",
+    <<-EOT
+    prometheus:
+      prometheusSpec:
+        externalLabels:
+          cluster: ${var.cluster_name}
+          environment: ${var.cluster_name}
+    alertmanager:
+      config:
+        global:
+          slack_api_url: ${var.slack_api_url}
+        receivers:
+        - name: blackhole
+        - name: reducto-alerts
+          slack_configs:
+          - channel: '${var.slack_channel}'
+            send_resolved: true
+    EOT
+
+  ]
+
+  depends_on = [
+    kubectl_manifest.monitoring_ns,
+    helm_release.prometheus_crds,
+    helm_release.ingress_nginx,
+  ]
+}

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -1,0 +1,26 @@
+resource "kubectl_manifest" "monitoring_ns" {
+  yaml_body = <<-YAML
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      name: monitoring
+    name: monitoring
+  spec:
+    finalizers:
+    - kubernetes
+  YAML
+}
+
+resource "helm_release" "prometheus_crds" {
+  name             = "prometheus-operator-crds"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus-operator-crds"
+  version          = "20.0.0"
+  namespace        = "monitoring"
+  create_namespace = false
+
+  depends_on = [
+    kubectl_manifest.monitoring_ns,
+  ]
+}

--- a/reducto-bucket.tf
+++ b/reducto-bucket.tf
@@ -21,6 +21,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "reducto_storage_lifecycle" {
     expiration {
       days = 1
     }
+
+    filter {
+      prefix = ""
+    }
   }
 }
 

--- a/telegraf.tf
+++ b/telegraf.tf
@@ -1,0 +1,57 @@
+resource "helm_release" "telegraf" {
+  name             = "telegraf"
+  repository       = "https://helm.influxdata.com"
+  chart            = "telegraf"
+  version          = "1.8.55"
+  namespace        = "monitoring"
+  create_namespace = false
+
+  values = [
+    "${file("values/telegraf.yaml")}"
+  ]
+
+  depends_on = [
+    kubectl_manifest.monitoring_ns,
+    kubectl_manifest.telegraf,
+  ]
+}
+
+resource "kubectl_manifest" "telegraf" {
+  yaml_body = <<-YAML
+apiVersion: v1
+kind: Secret
+metadata:
+  name: telegraf
+  namespace: monitoring
+type: Opaque
+data:
+  DATABASE_URL: ${base64encode(local.database_url)}
+  YAML
+
+  depends_on = [
+    kubectl_manifest.monitoring_ns,
+  ]
+}
+
+resource "kubectl_manifest" "telegraf_sm" {
+  yaml_body = <<-YAML
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: telegraf
+  namespace: monitoring
+spec:
+  endpoints:
+  - path: /metrics
+    port: prometheus-client
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: telegraf
+      app.kubernetes.io/name: telegraf
+  YAML
+
+  depends_on = [
+    helm_release.prometheus_crds,
+    helm_release.kube_prometheus_stack,
+  ]
+}

--- a/values/ingress-nginx-controller.yaml
+++ b/values/ingress-nginx-controller.yaml
@@ -36,6 +36,11 @@ controller:
             - ingress-nginx
         topologyKey: "topology.kubernetes.io/zone"
 
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+
   service:
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-scheme                              : "internal"

--- a/values/kube-prometheus-stack.yaml
+++ b/values/kube-prometheus-stack.yaml
@@ -1,0 +1,238 @@
+crds:
+  enabled: false
+
+defaultRules:
+  create: false
+
+alertmanager:
+  serviceMonitor:
+    selfMonitor: false
+
+  config:
+    global:
+      resolve_timeout: 1m
+    route:
+      receiver: 'reducto-alerts'
+      group_by: ['alertname', 'cluster', 'namespace']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 25m
+      routes:
+      - receiver: 'blackhole'
+        match:
+          alertname: Watchdog
+
+    templates:
+    - '/etc/alertmanager/config/*.tmpl'
+
+  templateFiles:
+    slack.tmpl: |-
+      {{/* Severity of the alert */}}
+      {{ define "__alert_severity" -}}
+          {{- if eq .CommonLabels.severity "critical" -}}
+          *Severity:* `Critical`
+          {{- else if eq .CommonLabels.severity "warning" -}}
+          *Severity:* `Warning`
+          {{- else if eq .CommonLabels.severity "info" -}}
+          *Severity:* `Info`
+          {{- else -}}
+          *Severity:* :question: {{ .CommonLabels.severity }}
+          {{- end }}
+      {{- end }}
+
+      {{ define "__single_message_title" }}{{ range .Alerts.Firing }}{{ .Labels.alertname }}{{ end }}{{ range .Alerts.Resolved }}{{ .Labels.alertname }}{{ end }}{{ end }}
+
+      {{ define "slack.default.title" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ if or (and (eq (len .Alerts.Firing) 1) (eq (len .Alerts.Resolved) 0)) (and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 1)) }}{{ template "__single_message_title" . }}{{ end }}{{ end }}
+
+      {{ define "slack.default.text" }}
+      {{ if or (and (eq (len .Alerts.Firing) 1) (eq (len .Alerts.Resolved) 0)) (and (eq (len .Alerts.Firing) 0) (eq (len .Alerts.Resolved) 1)) }}
+      {{ range .Alerts.Firing }}
+      {{ if .Annotations.summary }}*Alert:* {{ .Annotations.summary }}{{ end }}
+      {{ if .Annotations.description }}*Description:* {{ .Annotations.description }}{{ end }}
+      {{ if .Annotations.logsUrl }}*LogsUrl:* <{{ .Annotations.logsUrl }}|click here>{{ end }}
+      *Details:*
+      {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+      {{ end }}
+      {{ end }}
+
+      {{ range .Alerts.Resolved }}
+      {{ if .Annotations.summary }}*Alert:* {{ .Annotations.summary }}{{ end }}
+      {{ if .Annotations.description }}*Description:* {{ .Annotations.description }}{{ end }}
+      *Details:*
+      {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+      {{ end }}
+      {{ end }}
+      {{ else }}
+      {{ if gt (len .Alerts.Firing) 0 }}
+      *Alerts Firing:*
+      {{ range .Alerts.Firing }}- `{{ .Labels.alertname }}` - {{ .Annotations.description }}
+      {{ end }}
+      *Common Labels:*
+      {{ range .GroupLabels.SortedPairs -}} • *{{ .Name }}:* `{{ .Value }}`
+      {{ end }}
+      {{ end }}
+      {{ if gt (len .Alerts.Resolved) 0 }}
+      *Alerts Resolved:*
+      {{ range .Alerts.Resolved }}- `{{ .Labels.alertname }}` - {{ .Annotations.description }}
+      {{ end }}
+      *Common Labels:*
+      {{ range .GroupLabels.SortedPairs -}} • *{{ .Name }}:* `{{ .Value }}`
+      {{ end }}
+      {{ end }}
+      {{ end }}
+      {{ end }}
+
+  alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp2
+          resources:
+            requests:
+              storage: 1Gi
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+
+    tolerations:
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
+      effect: "NoSchedule"
+
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: worker-type
+              operator: In
+              values:
+              - system
+
+prometheusOperator:
+  resources:
+    limits:
+      memory: 100Mi
+    requests:
+      cpu: 50m
+      memory: 100Mi
+  tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Exists"
+    effect: "NoSchedule"
+
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: worker-type
+            operator: In
+            values:
+            - system
+        - matchExpressions:
+          - key: karpenter.sh/capacity-type
+            operator: In
+            values:
+            - on-demand
+
+prometheus:
+  ingress:
+    enabled: false
+
+  prometheusSpec:
+    serviceAccountName: prometheus
+    ruleSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+    scrapeConfigSelectorNilUsesHelmValues: false
+    retention: 15d
+    retentionSize: 10GB #
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp2
+          resources:
+            requests:
+              storage: 20Gi
+    resources:
+      requests:
+        cpu: 1
+        memory: 4Gi
+
+    tolerations:
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
+      effect: "NoSchedule"
+
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: worker-type
+              operator: In
+              values:
+              - system
+
+    containers:
+      - name: prometheus
+        livenessProbe:
+          failureThreshold: 6
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        startupProbe:
+          failureThreshold: 30
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 10
+
+grafana:
+  enabled: false
+
+kubernetesServiceMonitors:
+  enabled: false
+
+kubeApiServer:
+  enabled: false
+
+kubelet:
+  enabled: false
+
+kubeControllerManager:
+  enabled: false
+
+coreDns:
+  enabled: false
+
+kubeEtcd:
+  enabled: false
+
+kubeScheduler:
+  enabled: false
+
+kubeProxy:
+  enabled: false
+
+kubeStateMetrics:
+  enabled: false
+
+kube-state-metrics:
+  enabled: false
+
+nodeExporter:
+  enabled: false
+
+prometheusNodeExporter:
+  enabled: false

--- a/values/kube-prometheus-stack.yaml
+++ b/values/kube-prometheus-stack.yaml
@@ -16,7 +16,7 @@ alertmanager:
       group_by: ['alertname', 'cluster', 'namespace']
       group_wait: 30s
       group_interval: 5m
-      repeat_interval: 25m
+      repeat_interval: 4h
       routes:
       - receiver: 'blackhole'
         match:

--- a/values/telegraf.yaml
+++ b/values/telegraf.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 1
 
 resources:
   requests:

--- a/values/telegraf.yaml
+++ b/values/telegraf.yaml
@@ -1,0 +1,69 @@
+replicaCount: 2
+
+resources:
+  requests:
+    memory: 128Mi
+    cpu: 100m
+  limits:
+    memory: 128Mi
+
+tolerations:
+- key: "CriticalAddonsOnly"
+  operator: "Exists"
+  effect: "NoSchedule"
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: worker-type
+          operator: In
+          values:
+          - system
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - telegraf
+      topologyKey: "topology.kubernetes.io/zone"
+
+envFromSecret: "telegraf"
+
+
+config:
+  agent:
+    interval: "10s"
+    round_interval: true
+    metric_batch_size: 1000
+    metric_buffer_limit: 10000
+    collection_jitter: "0s"
+    flush_interval: "10s"
+    flush_jitter: "0s"
+    precision: ""
+    hostname: ""
+    omit_hostname: false
+
+  inputs:
+    - postgresql_extensible:
+        address: "${DATABASE_URL}"
+        query:
+          - measurement: "reducto_tasks"
+            sqlquery: "SELECT COUNT(*) AS count FROM tasks;"
+            tagvalue: ""
+          - measurement: "reducto_prioritytasks"
+            sqlquery: "SELECT COUNT(*) AS count FROM prioritytasks;"
+            tagvalue: ""
+
+  outputs:
+    - prometheus_client:
+        listen: ":9273"
+        metric_version: 2
+        path: "/metrics"
+        expiration_interval: "60s"
+        export_timestamp: false
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,7 @@ variable "cloudflare_api_token" {
 # Configuration for monitoring and alerting
 
 variable "slack_api_url" {
-  description = "Slack API URL for Alertmanager"
+  description = "Slack API/Webhook URL for Alertmanager"
   sensitive   = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -81,12 +81,8 @@ variable "cloudflare_api_token" {
 
 # Configuration for monitoring and alerting
 
-variable "slack_api_url" {
-  description = "Slack API/Webhook URL for Alertmanager"
+variable "slack_webhook_url" {
+  description = "Slack Webhook URL for Alertmanager"
   sensitive   = true
 }
 
-variable "slack_channel" {
-  description = "Slack channel where Alertmanager will send alerts"
-  default     = "#reducto-alerts"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -78,3 +78,15 @@ variable "cloudflare_api_token" {
   description = "Cloudflare API token for Cert Manager to use DNS solver for issuing TLS certificates"
   sensitive   = true
 }
+
+# Configuration for monitoring and alerting
+
+variable "slack_api_url" {
+  description = "Slack API URL for Alertmanager"
+  sensitive   = true
+}
+
+variable "slack_channel" {
+  description = "Slack channel where Alertmanager will send alerts"
+  default     = "#reducto-alerts"
+}


### PR DESCRIPTION
## Overview

- Setup Kube Prometheus Stack (Prometheus, Alertmanager, Prometheus Operator) 
- Setup Telegraf to export queue metrics from DB as prometheus metrics. 
- Configure Alertmanager to send following alerts to Slack webhook url:
   - When queue or priority queue size doesn't go down for 30mins send an alert
   - When API http status is 5xx for 15m send an alert.


## Tested



<img width="725" alt="Screenshot 2025-05-08 at 8 59 24 PM" src="https://github.com/user-attachments/assets/a67d17eb-5d19-4e4b-9c45-b0d3bc693ac0" />

