### PR TITLE
feat: option to create helm release in terraform

### DIFF
--- a/reducto-helm-release.tf
+++ b/reducto-helm-release.tf
@@ -1,4 +1,5 @@
 resource "helm_release" "reducto" {
+  count            = var.create_reducto_helm_release ? 1 : 0
   namespace        = "reducto"
   name             = "reducto"
   create_namespace = true

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,12 @@ variable "reducto_helm_chart" {
   default     = "oci://registry.reducto.ai/reducto-api/reducto"
 }
 
+variable "create_reducto_helm_release" {
+  description = "Create Reducto Helm Release, useful if you manage k8s resources outside of terraform"
+  type        = bool
+  default     = true
+}
+
 variable "reducto_host" {
   description = "Full host DNS for Reducto (Example: reducto.mydomain.com)"
 }


### PR DESCRIPTION
When k8s resources are managed outside of Terraform - `var.create_reducto_helm_release` can be used to disable creation of Helm Release from Terraform. 