### PR TITLE
feat: deploy dual vLLM services for citation and yaml extraction

### DIFF
--- a/docs/deploy_vllm_stack.mdx
+++ b/docs/deploy_vllm_stack.mdx
@@ -1,0 +1,102 @@
+---
+title: Deploying vLLM Stack to GPU Node Group
+---
+
+# Adding a GPU Node Group to the EKS Cluster
+
+This guide explains how to add the `system_gpu` node group to the EKS cluster using Terraform. This node group is intended for GPU workloads such as **vLLM** and other machine learning jobs.
+
+---
+
+## Step 1: Update the Terraform `eks` Module
+
+Locate the `eks_managed_node_groups` section in your `eks.tf`. Add the `system_gpu` node group configuration:
+
+```hcl
+system_gpu = {
+  ami_type       = "AL2023_x86_64_NVIDIA"
+  instance_types = ["g4dn.xlarge"]
+
+  min_size     = 1
+  max_size     = 2
+  desired_size = 1
+
+  labels = {
+    worker-type              = "system-gpu"
+    gpu_arch                 = "NVIDIAH100"
+    "nvidia.com/gpu.present" = "true"
+  }
+
+  block_device_mappings = {
+    root = {
+      device_name = "/dev/xvda"
+      ebs = {
+        volume_size           = 200
+        volume_type           = "gp3"
+        encrypted             = true
+        delete_on_termination = true
+      }
+    }
+  }
+
+  taints = {
+    gpu = {
+      key    = "nvidia.com/gpu"
+      value  = "Exists"
+      effect = "NO_SCHEDULE"
+    }
+  }
+}
+```
+
+---
+
+## Step 2: Enable the NVIDIA Device Plugin
+
+To allow Kubernetes to recognize GPU hardware, enable the NVIDIA device plugin:
+
+```hcl
+variable "enable_nvidia_device_plugin" {
+  type        = bool
+  default     = true
+  description = "Whether to install the NVIDIA device plugin for GPU support"
+}
+```
+
+⚠️ Ensure that all configuration values in `values/nvidia-device-plugin` are **uncommented and explicitly defined** 
+
+---
+
+## Step 3: Enable the vLLM Stack
+
+Enable deployment of the vLLM inference stack by updating the Terraform variable:
+
+```hcl
+variable "enable_vllm_stack" {
+  type        = bool
+  default     = true
+  description = "Whether to deploy the vLLM stack on the cluster"
+}
+```
+
+⚠️ Ensure that all configuration values in `values/vllm-stack.yaml` are **uncommented and explicitly defined** 
+
+---
+
+## Step 4: Export Hugging Face Token
+
+Before applying Terraform, export your Hugging Face access token so vLLM can authenticate and download models from Hugging Face Hub.
+
+```bash
+export vllm_stack_ht_token="<YOUR_HUGGINGFACE_TOKEN>"
+```
+
+---
+
+## Step 5: Apply the Terraform Changes
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```

--- a/docs/deploy_vllm_stack.mdx
+++ b/docs/deploy_vllm_stack.mdx
@@ -8,14 +8,14 @@ This guide explains how to add the `system_gpu` node group to the EKS cluster us
 
 ---
 
-## Step 1: Update the Terraform `eks` Module
+## Step 1: Verify the correct configurations are in Terraform `eks` Module
 
-Locate the `eks_managed_node_groups` section in your `eks.tf`. Add the `system_gpu` node group configuration:
+Locate the `eks_managed_node_groups` section in your `eks.tf`. Verify the `system_gpu` node group has following configuration and set the desired_size based on your requirement:
 
 ```hcl
 system_gpu = {
   ami_type       = "AL2023_x86_64_NVIDIA"
-  instance_types = ["g4dn.xlarge"]
+  instance_types = ["p5.48xlarge"]
 
   min_size     = 1
   max_size     = 2

--- a/eks.tf
+++ b/eks.tf
@@ -166,6 +166,41 @@ module "eks" {
       }
     }
 
+    system_gpu = {
+      ami_type       = "AL2023_x86_64_NVIDIA"
+      instance_types = ["p5.48xlarge"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 0
+
+      labels = {
+        worker-type              = "system-gpu"
+        gpu_arch                 = "NVIDIAH100"
+        "nvidia.com/gpu.present" = "true"
+      }
+
+      block_device_mappings = {
+        root = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 200
+            volume_type           = "gp3"
+            encrypted             = true
+            delete_on_termination = true
+          }
+        }
+      }
+
+      taints = {
+        gpu = {
+          key    = "nvidia.com/gpu"
+          value  = "Exists"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+
     // capacity for boostrapping workloads.
     // For example: cert-manager and nginx Jobs
     // before Karpenter could even provision capacity

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,12 @@ provider "kubectl" {
   load_config_file       = false
 }
 
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.eks.token
+}
+
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint

--- a/nvidia-device-plugin.tf
+++ b/nvidia-device-plugin.tf
@@ -1,0 +1,14 @@
+resource "helm_release" "nvidia_device_plugin" {
+  count = var.enable_nvidia_device_plugin ? 1 : 0
+
+  name       = "nvidia-device-plugin"
+  repository = "https://nvidia.github.io/k8s-device-plugin"
+  chart      = "nvidia-device-plugin"
+  namespace  = "kube-system"
+  version    = "0.17.4"
+
+  values = [file("values/nvidia-device-plugin.yaml")]
+
+
+  depends_on = [module.eks]
+}

--- a/values/nvidia-device-plugin.yaml
+++ b/values/nvidia-device-plugin.yaml
@@ -1,0 +1,16 @@
+# Nvidia device plugin Helm chart example values
+# tolerations:
+# - key: "nvidia.com/gpu"
+#   operator: "Exists"
+#   effect: "NoSchedule"
+
+
+# affinity:
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#       - matchExpressions:
+#         - key: "nvidia.com/gpu.present"
+#           operator: In
+#           values:
+#           - "true"

--- a/values/nvidia-device-plugin.yaml
+++ b/values/nvidia-device-plugin.yaml
@@ -1,16 +1,16 @@
 # Nvidia device plugin Helm chart example values
-# tolerations:
-# - key: "nvidia.com/gpu"
-#   operator: "Exists"
-#   effect: "NoSchedule"
+tolerations:
+- key: "nvidia.com/gpu"
+  operator: "Exists"
+  effect: "NoSchedule"
 
 
-# affinity:
-#   nodeAffinity:
-#     requiredDuringSchedulingIgnoredDuringExecution:
-#       nodeSelectorTerms:
-#       - matchExpressions:
-#         - key: "nvidia.com/gpu.present"
-#           operator: In
-#           values:
-#           - "true"
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: "nvidia.com/gpu.present"
+          operator: In
+          values:
+          - "true"

--- a/values/vllm-stack.yaml
+++ b/values/vllm-stack.yaml
@@ -1,0 +1,45 @@
+# vLLM Helm chart example values
+# servingEngineSpec:
+#   runtimeClassName: "nvidia"
+  
+#   # configuring for multiple serving engines deployments that runs different models
+#   modelSpec:
+#     - name: "llama3-8b"
+#       repository: "vllm/vllm-openai"
+#       tag: "latest"
+#       modelURL: meta-llama/Meta-Llama-3-8B-Instruct
+#       replicaCount: 1
+#       requestCPU: 4
+#       requestMemory: "16Gi"
+#       requestGPU: 1
+#       requestGPUType: "nvidia.com/gpu"
+
+#       # Node selection criteria
+#       nodeSelectorTerms:
+#         - matchExpressions:
+#             - key: "nvidia.com/gpu.product"
+#               operator: "In"
+#               values: ["A100-SXM4-80GB"]
+
+#       hf_token:
+#         secretName: "hf-token-secret"
+#         secretKey: "token"
+
+#     - name: "mixtral-8x7b"
+#       repository: "vllm/vllm-openai"
+#       tag: "latest"
+#       modelURL: mistralai/Mixtral-8x7B-Instruct-v0.1
+#       replicaCount: 1
+#       requestCPU: 4
+#       requestMemory: "16Gi"
+#       requestGPU: 1
+#       requestGPUType: "nvidia.com/gpu"
+#       nodeSelectorTerms:
+#         - matchExpressions:
+#             - key: "nvidia.com/gpu.product"
+#               operator: "In"
+#               values: ["H100-PCIe-80GB"]
+
+#       hf_token:
+#         secretName: "hf-token-secret"
+#         secretKey: "token"

--- a/values/vllm-stack.yaml
+++ b/values/vllm-stack.yaml
@@ -13,7 +13,7 @@ servingEngineSpec:
     privileged: true
 
   modelSpec:
-  - name: "tinyllama-gpu"
+  - name: "citation-7b-gpu"
     nodeSelectorTerms:
       - matchExpressions:
           - key: gpu_arch
@@ -22,20 +22,51 @@ servingEngineSpec:
               - NVIDIAH100 # Adjust based on your GPU architecture
     repository: "vllm/vllm-openai"
     tag: "v0.8.5.post1"
-    modelURL: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+    modelURL: "reducto/citation_7b_mimo_0812"
     replicaCount: 1
-    requestCPU: 1
-    requestMemory: "2Gi"
+    requestCPU: 2
+    requestMemory: "16Gi"
     requestGPU: 1
-    limitCPU: 2
-    limitMemory: "12Gi"
+    limitCPU: 4
+    limitMemory: "32Gi"
     pvcStorage: "200Gi"
     storageClass: "gp2"
     vllmConfig:
-      dtype:  "float16"
+      dtype: "float16"
       extraArgs:
         - "--disable-log-requests"
-        - "--gpu-memory-utilization=0.8" 
+        - "--gpu-memory-utilization=0.8"
+        - "--enforce-eager"
+        - "--port=8091"
+      hf_token:
+        secretName: "hf-token-secret"
+        secretKey: "token"
+  
+  - name: "yaml-extract-30b-gpu"
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: gpu_arch
+            operator: In
+            values:
+              - NVIDIAH200 # H200 GPU for larger model
+    repository: "lmsysorg/sglang"
+    tag: "v0.5.3rc1-cu126"
+    modelURL: "reducto/yaml_extract_30b_a3b_1003_v2"
+    replicaCount: 1
+    requestCPU: 4
+    requestMemory: "32Gi"
+    requestGPU: 1
+    limitCPU: 8
+    limitMemory: "64Gi"
+    pvcStorage: "400Gi"
+    storageClass: "gp2"
+    vllmConfig:
+      dtype: "float16"
+      extraArgs:
+        - "--log-level=info"
+        - "--port=8092"
+        - "--context-length=256000"
+        - "--attention-backend=fa3"
       hf_token:
         secretName: "hf-token-secret"
         secretKey: "token"
@@ -49,4 +80,4 @@ routerSpec:
       memory: "1Gi"
     limits:
       cpu: "2"
-      memory: "2Gi" 
+      memory: "2Gi"  

--- a/values/vllm-stack.yaml
+++ b/values/vllm-stack.yaml
@@ -1,52 +1,52 @@
 # vLLM Helm chart example values
-# servingEngineSpec:
-#   enableEngine: true
-#   runtimeClassName: "" 
-#   startupProbe:
-#     initialDelaySeconds: 60
-#     periodSeconds: 30
-#     failureThreshold: 120
-#     httpGet:
-#       path: /health
-#       port: 8000
-#   containerSecurityContext:
-#     privileged: true
+servingEngineSpec:
+  enableEngine: true
+  runtimeClassName: "" 
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    failureThreshold: 120
+    httpGet:
+      path: /health
+      port: 8000
+  containerSecurityContext:
+    privileged: true
 
-#   modelSpec:
-#   - name: "tinyllama-gpu"
-#     nodeSelectorTerms:
-#       - matchExpressions:
-#           - key: gpu_arch
-#             operator: In
-#             values:
-#               - NVIDIAH100 # Adjust based on your GPU architecture
-#     repository: "vllm/vllm-openai"
-#     tag: "v0.8.5.post1"
-#     modelURL: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
-#     replicaCount: 1
-#     requestCPU: 1
-#     requestMemory: "2Gi"
-#     requestGPU: 1
-#     limitCPU: 2
-#     limitMemory: "12Gi"
-#     pvcStorage: "200Gi"
-#     storageClass: "gp2"
-#     vllmConfig:
-#       dtype:  "float16"
-#       extraArgs:
-#         - "--disable-log-requests"
-#         - "--gpu-memory-utilization=0.8" 
-#       hf_token:
-#         secretName: "hf-token-secret"
-#         secretKey: "token"
+  modelSpec:
+  - name: "tinyllama-gpu"
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: gpu_arch
+            operator: In
+            values:
+              - NVIDIAH100 # Adjust based on your GPU architecture
+    repository: "vllm/vllm-openai"
+    tag: "v0.8.5.post1"
+    modelURL: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+    replicaCount: 1
+    requestCPU: 1
+    requestMemory: "2Gi"
+    requestGPU: 1
+    limitCPU: 2
+    limitMemory: "12Gi"
+    pvcStorage: "200Gi"
+    storageClass: "gp2"
+    vllmConfig:
+      dtype:  "float16"
+      extraArgs:
+        - "--disable-log-requests"
+        - "--gpu-memory-utilization=0.8" 
+      hf_token:
+        secretName: "hf-token-secret"
+        secretKey: "token"
 
-# routerSpec:
-#   enableRouter: true
-#   routingLogic: "roundrobin"
-#   resources:
-#     requests:
-#       cpu: "1"
-#       memory: "1Gi"
-#     limits:
-#       cpu: "2"
-#       memory: "2Gi" 
+routerSpec:
+  enableRouter: true
+  routingLogic: "roundrobin"
+  resources:
+    requests:
+      cpu: "1"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "2Gi" 

--- a/values/vllm-stack.yaml
+++ b/values/vllm-stack.yaml
@@ -1,45 +1,52 @@
 # vLLM Helm chart example values
 # servingEngineSpec:
-#   runtimeClassName: "nvidia"
-  
-#   # configuring for multiple serving engines deployments that runs different models
+#   enableEngine: true
+#   runtimeClassName: "" 
+#   startupProbe:
+#     initialDelaySeconds: 60
+#     periodSeconds: 30
+#     failureThreshold: 120
+#     httpGet:
+#       path: /health
+#       port: 8000
+#   containerSecurityContext:
+#     privileged: true
+
 #   modelSpec:
-#     - name: "llama3-8b"
-#       repository: "vllm/vllm-openai"
-#       tag: "latest"
-#       modelURL: meta-llama/Meta-Llama-3-8B-Instruct
-#       replicaCount: 1
-#       requestCPU: 4
-#       requestMemory: "16Gi"
-#       requestGPU: 1
-#       requestGPUType: "nvidia.com/gpu"
-
-#       # Node selection criteria
-#       nodeSelectorTerms:
-#         - matchExpressions:
-#             - key: "nvidia.com/gpu.product"
-#               operator: "In"
-#               values: ["A100-SXM4-80GB"]
-
+#   - name: "tinyllama-gpu"
+#     nodeSelectorTerms:
+#       - matchExpressions:
+#           - key: gpu_arch
+#             operator: In
+#             values:
+#               - NVIDIAH100 # Adjust based on your GPU architecture
+#     repository: "vllm/vllm-openai"
+#     tag: "v0.8.5.post1"
+#     modelURL: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+#     replicaCount: 1
+#     requestCPU: 1
+#     requestMemory: "2Gi"
+#     requestGPU: 1
+#     limitCPU: 2
+#     limitMemory: "12Gi"
+#     pvcStorage: "200Gi"
+#     storageClass: "gp2"
+#     vllmConfig:
+#       dtype:  "float16"
+#       extraArgs:
+#         - "--disable-log-requests"
+#         - "--gpu-memory-utilization=0.8" 
 #       hf_token:
 #         secretName: "hf-token-secret"
 #         secretKey: "token"
 
-#     - name: "mixtral-8x7b"
-#       repository: "vllm/vllm-openai"
-#       tag: "latest"
-#       modelURL: mistralai/Mixtral-8x7B-Instruct-v0.1
-#       replicaCount: 1
-#       requestCPU: 4
-#       requestMemory: "16Gi"
-#       requestGPU: 1
-#       requestGPUType: "nvidia.com/gpu"
-#       nodeSelectorTerms:
-#         - matchExpressions:
-#             - key: "nvidia.com/gpu.product"
-#               operator: "In"
-#               values: ["H100-PCIe-80GB"]
-
-#       hf_token:
-#         secretName: "hf-token-secret"
-#         secretKey: "token"
+# routerSpec:
+#   enableRouter: true
+#   routingLogic: "roundrobin"
+#   resources:
+#     requests:
+#       cpu: "1"
+#       memory: "1Gi"
+#     limits:
+#       cpu: "2"
+#       memory: "2Gi" 

--- a/variables.tf
+++ b/variables.tf
@@ -99,12 +99,6 @@ variable "datadog_api_key" {
 
 # Configuration for vLLM
 
-variable "enable_gpu_node_group" {
-  type        = bool
-  default     = false
-  description = "Whether to create the GPU node group in the EKS cluster"
-}
-
 variable "enable_nvidia_device_plugin" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -99,15 +99,29 @@ variable "datadog_api_key" {
 
 # Configuration for vLLM
 
+variable "enable_gpu_node_group" {
+  type        = bool
+  default     = false
+  description = "Whether to create the GPU node group in the EKS cluster"
+}
+
+variable "enable_nvidia_device_plugin" {
+  type        = bool
+  default     = false
+  description = "Whether to install the NVIDIA device plugin for GPU support"
+}
+
 variable "enable_vllm_stack" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
+  description = "Whether to deploy the vLLM stack on the cluster"
 }
 
 variable "vllm_stack_hf_token" {
-  type      = string
-  sensitive = true
-  default   = ""
+  type        = string
+  sensitive   = true
+  default     = ""
+  description = "Hugging Face API token used by the vLLM stack for model access"
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -97,3 +97,17 @@ variable "datadog_api_key" {
   default     = ""
 }
 
+# Configuration for vLLM
+
+variable "enable_vllm_stack" {
+  type    = bool
+  default = false
+}
+
+variable "vllm_stack_hf_token" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+

--- a/vllm-stack.tf
+++ b/vllm-stack.tf
@@ -1,0 +1,44 @@
+resource "kubernetes_namespace" "vllm_stack" {
+  count = var.enable_vllm_stack ? 1 : 0
+
+  metadata {
+    name = "vllm-stack"
+  }
+
+  depends_on = [module.eks]
+}
+
+resource "kubernetes_secret" "hf_token" {
+  count = var.enable_vllm_stack ? 1 : 0
+  metadata {
+    name      = "hf-token-secret"
+    namespace = kubernetes_namespace.vllm_stack[0].metadata[0].name
+  }
+  type = "Opaque"
+  data = { token = var.vllm_stack_hf_token }
+}
+
+resource "helm_release" "vllm_stack" {
+  count = var.enable_vllm_stack ? 1 : 0
+
+  name             = "vllm-stack"
+  repository       = "https://vllm-project.github.io/production-stack"
+  chart            = "vllm-stack"
+  version          = "0.1.7"
+  namespace        = kubernetes_namespace.vllm_stack[0].metadata[0].name
+  create_namespace = false
+
+  values = [file("values/vllm-stack.yaml")]
+
+  timeout         = 900
+  cleanup_on_fail = true
+  force_update    = true
+  recreate_pods   = true
+  wait            = true
+  wait_for_jobs   = true
+
+  depends_on = [
+    module.eks,
+    kubernetes_secret.hf_token,
+  ]
+}


### PR DESCRIPTION
# feat: deploy dual vLLM services for citation and yaml extraction

## Summary

Modified PR #12 to deploy **2 separate vLLM/SGLang services** instead of a single TinyLlama service:

1. **citation-7b-gpu**: `reducto/citation_7b_mimo_0812` model on port 8091 (vLLM, H100)
2. **yaml-extract-30b-gpu**: `reducto/yaml_extract_30b_a3b_1003_v2` model on port 8092 (SGLang, H200)

Both services use the same HuggingFace token secret (`hf-token-secret`) and are configured based on the models specified in:
- `src/reducto_modal/finegrained_citation.py` 
- `src/reducto_modal/yaml_extract.py`

**⚠️ CRITICAL ISSUES IDENTIFIED:**
- The yaml-extract service requires **H200 GPUs** but the EKS node group only provisions **H100 GPUs** (p5.48xlarge)
- The yaml-extract service uses **SGLang container** (`lmsysorg/sglang`) but the vllm-stack helm chart is designed for **vLLM only**

## Review & Testing Checklist for Human

- [ ] **GPU Architecture Alignment** - The `system_gpu` node group in `eks.tf` provisions `p5.48xlarge` instances labeled as `NVIDIAH100`, but `yaml-extract-30b-gpu` service requires `NVIDIAH200`. Either change the node group to provision H200 GPUs or update the yaml-extract service to use H100.

- [ ] **SGLang Compatibility** - The vllm-stack helm chart (v0.1.7) expects vLLM containers, but the yaml-extract service uses `lmsysorg/sglang`. Verify if the chart supports SGLang, or if we need a separate helm release/approach for deploying SGLang workloads.

- [ ] **Port Configuration** - Custom ports (8091, 8092) are specified in `extraArgs`, but the `startupProbe` in the shared config checks port 8000. Test that the helm chart properly exposes these custom ports and that health checks work correctly for both services.

- [ ] **Resource Allocation** - Verify the p5.48xlarge instance type can handle both services concurrently (combined: 6-12 CPUs, 48-96GB RAM, 2 GPUs). The `desired_size=0` in the node group means no GPU nodes will be provisioned by default.

- [ ] **End-to-End Testing** - Deploy to a test cluster with GPU nodes and verify both services start successfully, pass health checks, and can serve inference requests on their respective ports.

### Recommended Test Plan
1. Set `desired_size=1` in `eks.tf` for the `system_gpu` node group
2. Apply terraform with `enable_nvidia_device_plugin=true` and `enable_vllm_stack=true`
3. Check pod status: `kubectl get pods -n reducto -l app.kubernetes.io/name=vllm-stack`
4. Review pod logs for startup errors
5. Port-forward and test inference: `curl http://localhost:8091/health` and `curl http://localhost:8092/health`

### Notes
- This work was done by Devin in session: https://app.devin.ai/sessions/2b17ec255fe54d7ab2f6d41db41b28a7
- Requested by: Raunak Chowdhuri (@raunakdoesdev)
- Original PR #12 by lasantha-jay provided the base infrastructure setup
- The configuration is based on Modal deployment code but not yet tested on Kubernetes/Helm