### PR TITLE
Upgrade Kubernetes from 1.31 to 1.32

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,56 @@
+# Kubernetes Version Upgrade Guide
+
+## Overview
+
+This guide covers upgrading your EKS cluster from Kubernetes 1.31 to 1.32.
+
+## Changes
+
+### Kubernetes Version
+- **From:** 1.31
+- **To:** 1.32
+
+### EKS Add-on Version Updates
+
+| Add-on | Previous Version | New Version |
+|--------|-----------------|-------------|
+| CoreDNS | v1.11.3-eksbuild.1 | v1.11.4-eksbuild.24 |
+| kube-proxy | v1.30.3-eksbuild.9 | v1.32.6-eksbuild.13 |
+| VPC CNI | v1.18.5-eksbuild.1 | v1.20.4-eksbuild.1 |
+| EBS CSI Driver | v1.36.0-eksbuild.1 | v1.37.0-eksbuild.1 |
+| Pod Identity Agent | v1.3.2-eksbuild.2 | v1.3.4-eksbuild.1 |
+
+## Migration Steps
+
+1. **Review the changes**
+   ```bash
+   git diff main
+   ```
+
+2. **Plan the upgrade**
+   ```bash
+   terraform plan
+   ```
+
+3. **Apply the upgrade**
+   ```bash
+   terraform apply
+   ```
+
+4. **Verify cluster health**
+   ```bash
+   kubectl get nodes
+   kubectl get pods -A
+   ```
+
+## Notes
+
+- The upgrade process is handled automatically by Terraform
+- EKS will perform a rolling upgrade of the control plane
+- Add-ons will be updated after the control plane upgrade completes
+- Node groups will continue running during the control plane upgrade
+- Minimal downtime is expected for the control plane during the upgrade
+
+## Rollback
+
+If issues occur, you can rollback by reverting the changes and running `terraform apply` again with the previous versions.

--- a/eks.tf
+++ b/eks.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "20.26.0"
 
   cluster_name    = var.cluster_name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
 
   cluster_endpoint_public_access       = var.cluster_endpoint_public_access
   cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
@@ -21,7 +21,7 @@ module "eks" {
 
   cluster_addons = {
     coredns = {
-      addon_version     = "v1.11.3-eksbuild.1"
+      addon_version     = "v1.11.4-eksbuild.24"
       resolve_conflicts = "OVERWRITE"
       configuration_values = jsonencode({
         autoScaling = {
@@ -59,7 +59,7 @@ module "eks" {
     }
 
     eks-pod-identity-agent = {
-      addon_version     = "v1.3.2-eksbuild.2"
+      addon_version     = "v1.3.4-eksbuild.1"
       resolve_conflicts = "OVERWRITE"
       configuration_values = jsonencode({
         resources = {
@@ -75,7 +75,7 @@ module "eks" {
     }
 
     kube-proxy = {
-      addon_version     = "v1.30.3-eksbuild.9"
+      addon_version     = "v1.32.6-eksbuild.13"
       resolve_conflicts = "OVERWRITE"
       configuration_values = jsonencode({
         resources = {
@@ -91,7 +91,7 @@ module "eks" {
     }
 
     vpc-cni = {
-      addon_version     = "v1.18.5-eksbuild.1"
+      addon_version     = "v1.20.4-eksbuild.1"
       resolve_conflicts = "OVERWRITE"
       configuration_values = jsonencode({
         resources = {
@@ -108,7 +108,7 @@ module "eks" {
 
     aws-ebs-csi-driver = {
       service_account_role_arn = module.ebs_csi_irsa_role.iam_role_arn
-      addon_version            = "v1.36.0-eksbuild.1"
+      addon_version            = "v1.37.0-eksbuild.1"
       resolve_conflicts        = "OVERWRITE"
 
       configuration_values = jsonencode({


### PR DESCRIPTION
# Upgrade Kubernetes from 1.31 to 1.32

## Summary

This PR upgrades the EKS cluster from Kubernetes 1.31 to 1.32 and updates all EKS addons to compatible versions. A migration guide has been added to document the upgrade process and addon version changes.

**Changes:**
- Kubernetes cluster version: `1.31` → `1.32`
- CoreDNS: `v1.11.3-eksbuild.1` → `v1.11.4-eksbuild.24`
- kube-proxy: `v1.30.3-eksbuild.9` → `v1.32.6-eksbuild.13`
- VPC CNI: `v1.18.5-eksbuild.1` → `v1.20.4-eksbuild.1`
- EBS CSI Driver: `v1.36.0-eksbuild.1` → `v1.37.0-eksbuild.1`
- Pod Identity Agent: `v1.3.2-eksbuild.2` → `v1.3.4-eksbuild.1`

## Review & Testing Checklist for Human

- [ ] **Verify addon versions** - Double-check EBS CSI Driver (v1.37.0) and Pod Identity Agent (v1.3.4) versions against [AWS EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html) for k8s 1.32 compatibility. CoreDNS, kube-proxy, and VPC CNI versions were confirmed from official docs.
- [ ] **Review k8s 1.32 breaking changes** - Check [Kubernetes 1.32 release notes](https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/) for any API deprecations or breaking changes that could affect Reducto or other workloads.
- [ ] **Test in non-production first** - Apply this upgrade to a staging/dev cluster before production to verify no issues with the Reducto application.
- [ ] **Verify upgrade path** - Confirm with AWS documentation that upgrading directly from 1.31 to 1.32 is supported without intermediate versions.
- [ ] **Plan maintenance window** - While EKS performs rolling upgrades, consider scheduling this during low-traffic periods.

### Test Plan
1. Run `terraform plan` to review the changes
2. Apply to a non-production cluster first
3. After applying, verify:
   ```bash
   kubectl get nodes  # Check node versions
   kubectl get pods -A  # Ensure all pods are running
   kubectl get addons -n kube-system  # Verify addon versions
   ```
4. Test Reducto application functionality end-to-end
5. Monitor cluster and application metrics for anomalies

### Notes
- The upgrade is minimal as requested - only version numbers updated
- Terraform will handle the rolling upgrade automatically
- EKS control plane upgrade happens first, then addons
- Node groups will continue running during control plane upgrade

---

**Link to Devin run:** https://app.devin.ai/sessions/7211a88c55084fa0a9d2564dfb5fccde  
**Requested by:** Raunak Chowdhuri (@raunakdoesdev)