### PR TITLE
RED-1124: Disable TLS 1.0 and TLS 1.1, only allow TLS 1.2+

### DIFF
--- a/values/ingress-nginx-controller.yaml
+++ b/values/ingress-nginx-controller.yaml
@@ -1,5 +1,10 @@
 controller:
   replicaCount: 2
+
+  # Security: Disable TLS 1.0 and TLS 1.1, only allow TLS 1.2 and TLS 1.3
+  config:
+    ssl-protocols: "TLSv1.2 TLSv1.3"
+
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Summary

Addresses pentest finding RED-1124 by configuring the NGINX ingress controller to only accept TLS 1.2 and TLS 1.3 connections. TLS 1.0 and TLS 1.1 have known vulnerabilities and are deprecated.

The change adds the `ssl-protocols` configuration to the NGINX ingress controller's ConfigMap via the Helm values file.

## Review & Testing Checklist for Human

- [ ] Verify the `ssl-protocols: "TLSv1.2 TLSv1.3"` syntax is correct for NGINX (space-separated protocol names)
- [ ] After deployment, run a TLS scan (e.g., `testssl.sh` or `nmap --script ssl-enum-ciphers`) against the ingress endpoint to confirm TLS 1.0/1.1 are rejected
- [ ] Confirm no critical API clients require TLS 1.0/1.1 (very unlikely as TLS 1.2 has been standard since 2008)

### Notes

This is one of three PRs addressing this pentest finding across all on-prem infrastructure repos (AWS, Azure, GCP).

- Requested by: Arth Bohra (@arthbohra)
- Link to Devin run: https://app.devin.ai/sessions/48e4a8ecef0e467cba67a65d5aa10113