### PR TITLE
Set CloudWatch log group retention to 90 days for EKS control plane logs

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -19,6 +19,8 @@ module "eks" {
     "scheduler",
   ]
 
+  cloudwatch_log_group_retention_in_days = 90
+
   addons = {
     coredns = {
       addon_version = "v1.13.1-eksbuild.1"


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/reductoai/reducto-onprem-infra/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
